### PR TITLE
Update mysqlbackup.py

### DIFF
--- a/mysqlbackup.py
+++ b/mysqlbackup.py
@@ -146,7 +146,7 @@ def main(argv):
       elif opt in ("-k", "--keep"):                
         keep = int(arg)
       elif opt in ("-d", "--databases"):                
-        server = arg                
+        databases = arg                
       elif opt in ("-t", "--store"): 
         store = arg
       elif opt in ("-u", "--user"): 


### PR DESCRIPTION
When I specify '--databases' parameter in the script to backup 1 database, all databases are backed up anyway. There's probably a mistake in your parameter assignment.
