### PR TITLE
Load configuration from json file and list and restore backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Use the -h or the --help flag to get a listing of options.
        [-u | --user] the database user
        [-p | --password] the database password
        [-s | --host] the database server hostname
+       [-o | --options] the json file to load the options from instead of using command line
+       [-r | --restore] enables restore mode
 
 License and Bug Fixes
 ===========

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Pushed Filesystem Backups
 ===========
 Pushed filesystem backups are done through the pushbackup.py script.
 
-his is an incremental backup system that pushes to a remote server.  Useful
+This is an incremental backup system that pushes to a remote server.  Useful
 for remote systems that aren't always on (laptops).  Backups use rsync and hard 
 links to keep multiple full copies while using minimal space.  It is assumed
 that the rotatebackups.py script exists on the remote backup server and that

--- a/mysqlbackup.py
+++ b/mysqlbackup.py
@@ -99,7 +99,7 @@ class MysqlBackup:
       if not prev_date:
         prev_date = date
 
-      if (date != prev_date) or (i+1 == len(backups)):
+      if (date != prev_date):
         print "["+str(k)+"]", "(%s) %s" % (format_date(prev_date), databases)
 
         options[k] = {
@@ -116,6 +116,7 @@ class MysqlBackup:
       databases += ("" if databases == "" else ",") + data[1]
       filenames += ("" if filenames == "" else ",") + backups[i]
 
+    print "["+str(k)+"]", "(%s) %s" % (format_date(prev_date), databases)
     options[k] = {
       "date": prev_date,
       "databases": databases,

--- a/mysqlbackup.py
+++ b/mysqlbackup.py
@@ -193,7 +193,7 @@ class MysqlBackup:
     tstamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")    
     dbs = self.get_databases()
     skip = ["information_schema", "performance_schema", "test"]
-    for db in databases:
+    for db in dbs:
       if db in skip:
         continue
 

--- a/mysqlbackup.py
+++ b/mysqlbackup.py
@@ -266,6 +266,7 @@ def main(argv):
         fopts = json.load(content_file)
     
     # merge with opts
+    opts_keys = map(lambda val: val[0], opts)
     if fopts:
       for key in fopts.keys():
         prefix = ""
@@ -275,7 +276,8 @@ def main(argv):
           prefix = "--"
         else:
           continue
-        opts.append((prefix+key, fopts[key]))
+        if prefix+key not in opts_keys:
+          opts.append((prefix+key, fopts[key]))
             
     # loop through all of the command line options and set the appropriate
     # values, overriding defaults


### PR DESCRIPTION
Adds the option to load the configuration from a json file instead of using the command line. The json file should be a dictionary using the same keywords displayed in the help command and the values. The file to be loaded can be specified using the "--options" trigger.

Also it adds the option to restore a backup with the "-r" or "--restore" trigger. It allows to interactively select the backup files to use and which databases to backup. It uses the same parameters as the backup mode.

![screenshot_20170123_223812](https://cloud.githubusercontent.com/assets/143359/22230509/c73536c8-e1bc-11e6-9972-9a4d93ecd8ca.png)