### PR TITLE
Adding support for non-standard ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ exclude filter rules.
 To use a non-standard port, include this to the config file along with the "backup" and "exclude" blocks. An exmple with port 2345 is shown. If no port block is given, port 22 is used by default.
 
       "port" : [
-	"ssh -p 2345"
+        "ssh -p 2345"
       ]
 
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ exclude filter rules.
       ]
     }
 
+To use a non-standard port, include this to the config file along with the "backup" and "exclude" blocks. An exmple with port 2345 is shown. If no port block is given, port 22 is used by default.
+
+      "port" : [
+	"ssh -p 2345"
+      ]
+
+
 Usually the backup scripts are run from a remote, off-site, server pulling down
 content from the servers to backup.  Scripts are usually setup to run from cron
 periodically.

--- a/incrbackup.py
+++ b/incrbackup.py
@@ -59,8 +59,6 @@ class IncrementalBackup:
     
   def run_command(self, command=None, shell=False, ignore_errors=False, 
     ignore_codes=None):
-    #print(command)
-    #exit()
     result = subprocess.call(command, shell=False)
     if result and not ignore_errors and (not ignore_codes or result in set(ignore_codes)):
       raise BaseException(str(command) + " " + str(result))

--- a/incrbackup.py
+++ b/incrbackup.py
@@ -59,6 +59,8 @@ class IncrementalBackup:
     
   def run_command(self, command=None, shell=False, ignore_errors=False, 
     ignore_codes=None):
+    #print(command)
+    #exit()
     result = subprocess.call(command, shell=False)
     if result and not ignore_errors and (not ignore_codes or result in set(ignore_codes)):
       raise BaseException(str(command) + " " + str(result))
@@ -100,6 +102,10 @@ class IncrementalBackup:
         for exclude in config["exclude"]:
           rsync_base.extend(["--exclude", exclude])
     
+      if "port" in config:
+	for thePort in config["port"]:
+          rsync_base.extend(["-e", thePort])
+
     # one rsync command per path, ignore files vanished errors
     for bpath in bpaths:
       bpath = bpath.strip()


### PR DESCRIPTION
I have some servers where ssh is configured to use a non-standard port. I added a block in the config file and add it to rsync_base to connect on a different port. If the "port" isn't included, the script runs with port 22 by default.